### PR TITLE
Add ASCII board export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ vite.config.ts.timestamp-*
 
 # ralphex progress logs
 .ralphex/progress/
+
+# git worktrees
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A fully playable browser-based Sudoku with three difficulty levels, pencil notes
 - **Undo/Redo** — Ctrl+Z / Ctrl+Shift+Z (or Ctrl+Y), because mistakes happen
 - **Hint** — Press `v` or click the Hint button to get a logical hint; the board selects the target cell and explains why the move is valid; press Esc to dismiss
 - **Jump mode** — Press Space, then two digits (row, col) to teleport to any cell
+- **ASCII export** — Press `p` to copy the current board as a bordered ASCII grid to the clipboard
 - **Status bar** — Contextual shortcut hints so you don't have to memorize everything
 - **Win detection** — Fill it all in correctly and get a satisfying overlay
 - **Completion animations** — Blue flash on cells when a row, column, or box is completed; matching blue flash on the number pad button when all 9 of a digit are placed

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -27,6 +27,14 @@ function useStatusHint(): StatusHint | null {
             uiSnap.selected as CellPos | null,
         ) !== null
 
+    if (uiSnap.copied) {
+        return {
+            label: "COPIED",
+            text: "Board copied to clipboard",
+            shortcuts: [],
+        }
+    }
+
     if (find.active) {
         return {
             label: "FIND",

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -69,6 +69,7 @@ function useStatusHint(): StatusHint | null {
         { key: "Space", action: "jump" },
         { key: "F", action: "find" },
         { key: "w / W", action: "candidates" },
+        { key: "p", action: "copy" },
     ]
     if (hasLastOne) {
         shortcuts.push({ key: "X", action: "last one" })

--- a/src/export.test.ts
+++ b/src/export.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { boardToAscii } from "./export"
+
+const SEP = "+-------+-------+-------+"
+
+function makeBoard(fill: number): number[][] {
+    return Array.from({ length: 9 }, () => Array(9).fill(fill))
+}
+
+describe("boardToAscii", () => {
+    it("empty board has all dots and correct separators", () => {
+        const board = makeBoard(0)
+        const result = boardToAscii(board)
+        const lines = result.split("\n")
+
+        expect(lines).toHaveLength(13)
+        expect(lines[0]).toBe(SEP)
+        expect(lines[4]).toBe(SEP)
+        expect(lines[8]).toBe(SEP)
+        expect(lines[12]).toBe(SEP)
+
+        for (const line of lines) {
+            if (line === SEP) continue
+            expect(line).not.toMatch(/[1-9]/)
+            expect(line).toMatch(/\| \. \. \. \| \. \. \. \| \. \. \. \|/)
+        }
+    })
+
+    it("fully filled board shows all digits, no dots", () => {
+        const board = Array.from({ length: 9 }, (_, row) =>
+            Array.from({ length: 9 }, (_, col) => ((row * 9 + col) % 9) + 1),
+        )
+        const result = boardToAscii(board)
+        expect(result).not.toContain(".")
+        expect(result).toContain(SEP)
+    })
+
+    it("partial board shows correct mix of dots and digits", () => {
+        const board = makeBoard(0)
+        board[0][0] = 5
+        board[0][1] = 3
+        board[4][4] = 7
+
+        const result = boardToAscii(board)
+        const lines = result.split("\n")
+
+        // First data row: 5 3 . | . . . | . . .
+        expect(lines[1]).toBe("| 5 3 . | . . . | . . . |")
+        // Middle row (row index 4, line index 4+2=6 counting separators)
+        expect(lines[6]).toBe("| . . . | . 7 . | . . . |")
+    })
+})

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,0 +1,14 @@
+const SEP = "+-------+-------+-------+"
+
+export function boardToAscii(board: number[][]): string {
+    const lines: string[] = []
+    for (let row = 0; row < 9; row++) {
+        if (row % 3 === 0) lines.push(SEP)
+        const c = board[row].map((v) => (v === 0 ? "." : String(v)))
+        lines.push(
+            `| ${c[0]} ${c[1]} ${c[2]} | ${c[3]} ${c[4]} ${c[5]} | ${c[6]} ${c[7]} ${c[8]} |`,
+        )
+    }
+    lines.push(SEP)
+    return lines.join("\n")
+}

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -24,6 +24,7 @@ interface GameUI {
     difficulty: Difficulty
     elapsed: number
     notesMode: boolean
+    copied: boolean
 }
 
 function emptyNotes(): number[][][] {
@@ -51,6 +52,7 @@ function createInitialUI(
         difficulty,
         elapsed: 0,
         notesMode: false,
+        copied: false,
     }
 }
 

--- a/src/useKeyboard.ts
+++ b/src/useKeyboard.ts
@@ -1,4 +1,5 @@
 import { useEffect } from "react"
+import { boardToAscii } from "./export"
 import { handleKey as findHandleKey } from "./store/findStore"
 import {
     clearCell,
@@ -103,6 +104,10 @@ export function useKeyboard() {
                 fillAllCandidateNotes()
             } else if (e.key === "v") {
                 showHint()
+            } else if (e.key === "p") {
+                navigator.clipboard.writeText(
+                    boardToAscii(gameData.value.board),
+                )
             } else if (e.key === "Escape") {
                 dismissHint()
             }

--- a/src/useKeyboard.ts
+++ b/src/useKeyboard.ts
@@ -108,6 +108,10 @@ export function useKeyboard() {
                 navigator.clipboard.writeText(
                     boardToAscii(gameData.value.board),
                 )
+                gameUI.copied = true
+                setTimeout(() => {
+                    gameUI.copied = false
+                }, 2000)
             } else if (e.key === "Escape") {
                 dismissHint()
             }


### PR DESCRIPTION
Closes #24

## Summary

- Add `boardToAscii()` pure function in `src/export.ts` — converts a 9×9 board to a bordered ASCII grid
- Press `p` to copy the current board to the clipboard
- Empty cells render as `.`, filled cells show their digit
- Add `p → copy` hint to the StatusBar

## Output format

```
+-------+-------+-------+
| 5 3 . | . 7 . | . . . |
| 6 . . | 1 9 5 | . . . |
| . 9 8 | . . . | . 6 . |
+-------+-------+-------+
| 8 . . | . 6 . | . . 3 |
| 4 . . | 8 . 3 | . . 1 |
| 7 . . | . 2 . | . . 6 |
+-------+-------+-------+
| . 6 . | . . . | 2 8 . |
| . . . | 4 1 9 | . . 5 |
| . . . | . 8 . | . 7 9 |
+-------+-------+-------+
```

## Test Plan

- [ ] `npm run test` — 187 tests pass including 3 new export tests
- [ ] `npm run check` — no lint/format errors
- [ ] Open game, press `p`, paste into text editor — verify bordered grid
- [ ] Empty board copies with all dots; partial board shows correct digits