### PR TITLE
Code quality: remove duplication and add clarifying comments

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { useEffect, useLayoutEffect, useRef } from "react"
+import { useFlashAnimation } from "../hooks/useFlashAnimation"
 import { computeFull } from "../store/gameStore"
 import type { CellPos } from "../useGame"
 import { Cell } from "./Cell"
@@ -72,35 +73,19 @@ export function Board({
     // that cell. Using counts (instead of a boolean Set) ensures that intersection
     // cells shared by two overlapping flashes stay lit until the last timer clears them:
     // each timer only decrements, and a cell is removed only when its count reaches 0.
-    const [flashCells, setFlashCells] = useState(
-        () => new Map<string, number>(),
-    )
+    const {
+        flashMap: flashCells,
+        flash: flashBoard,
+        reset: resetFlash,
+    } = useFlashAnimation<string>(700)
 
-    // Holds all pending flash-clear timers so they can be cancelled on unmount or
-    // new-game reset. We intentionally do NOT cancel these timers when completedSig
-    // changes: each timer clears only its own cells via closure, so concurrent timers
-    // are safe. Cancelling on re-run would leave cells permanently stuck in flashCells
-    // if a second completion (or an undo) fires within the 700 ms window.
-    const flashTimersRef = useRef<ReturnType<typeof setTimeout>[]>([])
-
-    useEffect(() => {
-        return () => {
-            for (const t of flashTimersRef.current) clearTimeout(t)
-        }
-    }, [])
-
-    // Reset all flash state when a new game starts (initial changes). Clears any
-    // residual flashCells entries, cancels pending timers, and resets the previous
-    // completion tracking so old animations cannot bleed into the new puzzle.
-    // useLayoutEffect ensures this runs synchronously before the browser paints, so
-    // stale flashCells from the previous game are never visible on the first frame.
-    // Calling setFlashCells inside useLayoutEffect triggers a synchronous re-render
-    // before paint, guaranteeing a clean slate for the new puzzle.
+    // Reset all flash state when a new game starts (initial changes). Calls resetFlash()
+    // to cancel pending timers and clear the map, then resets the previous completion
+    // tracking so old animations cannot bleed into the new puzzle.
+    // useLayoutEffect ensures this runs synchronously before the browser paints.
     // biome-ignore lint: initial is a prop — its reference change is the intended trigger
     useLayoutEffect(() => {
-        for (const t of flashTimersRef.current) clearTimeout(t)
-        flashTimersRef.current = []
-        setFlashCells(new Map())
+        resetFlash()
         prevCompletedRef.current = {
             rows: new Set<number>(),
             cols: new Set<number>(),
@@ -144,28 +129,7 @@ export function Board({
                     cells.add(`${r},${c}`)
             }
 
-        setFlashCells((prev) => {
-            const next = new Map(prev)
-            for (const cell of cells) next.set(cell, (next.get(cell) ?? 0) + 1)
-            return next
-        })
-
-        const timer = setTimeout(() => {
-            setFlashCells((prev) => {
-                const next = new Map(prev)
-                for (const cell of cells) {
-                    const count = next.get(cell) ?? 0
-                    if (count <= 1) next.delete(cell)
-                    else next.set(cell, count - 1)
-                }
-                return next
-            })
-            flashTimersRef.current = flashTimersRef.current.filter(
-                (t) => t !== timer,
-            )
-        }, 700)
-
-        flashTimersRef.current.push(timer)
+        flashBoard(cells)
     }, [completedSig])
 
     return (

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { computeFull } from "../store/gameStore"
 import type { CellPos } from "../useGame"
 import { Cell } from "./Cell"
 
@@ -28,16 +29,7 @@ export function Board({
 }: BoardProps) {
     const selectedValue = selected ? board[selected.row][selected.col] : 0
 
-    const completedDigits = new Set<number>()
-    const digitCounts = new Map<number, number>()
-    for (let r = 0; r < 9; r++)
-        for (let c = 0; c < 9; c++) {
-            const v = board[r][c]
-            if (v !== 0 && !errors.has(`${r},${c}`))
-                digitCounts.set(v, (digitCounts.get(v) ?? 0) + 1)
-        }
-    for (const [digit, count] of digitCounts)
-        if (count >= 9) completedDigits.add(digit)
+    const completedDigits = computeFull(board, errors)
 
     const completedRows = new Set<number>()
     const completedCols = new Set<number>()

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef } from "react"
+import { useFlashAnimation } from "../hooks/useFlashAnimation"
 import { computeFull } from "../store/gameStore"
 
 interface NumberPadProps {
@@ -45,17 +46,8 @@ export function NumberPad({
     const prevFull = useRef(new Set<number>())
     const isFirstRun = useRef(true)
 
-    const [flashDigits, setFlashDigits] = useState(
-        () => new Map<number, number>(),
-    )
-    const flashTimersRef = useRef<ReturnType<typeof setTimeout>[]>([])
-
-    // Cancel all pending timers on unmount.
-    useEffect(() => {
-        return () => {
-            for (const t of flashTimersRef.current) clearTimeout(t)
-        }
-    }, [])
+    const { flashMap: flashDigits, flash: flashPad } =
+        useFlashAnimation<number>(1400)
 
     useEffect(() => {
         const currentFull = computeFull(board, errors)
@@ -75,29 +67,8 @@ export function NumberPad({
 
         if (newlyComplete.length === 0) return
 
-        setFlashDigits((prev) => {
-            const next = new Map(prev)
-            for (const n of newlyComplete) next.set(n, (next.get(n) ?? 0) + 1)
-            return next
-        })
-
-        const timer = setTimeout(() => {
-            setFlashDigits((prev) => {
-                const next = new Map(prev)
-                for (const n of newlyComplete) {
-                    const count = next.get(n) ?? 0
-                    if (count <= 1) next.delete(n)
-                    else next.set(n, count - 1)
-                }
-                return next
-            })
-            flashTimersRef.current = flashTimersRef.current.filter(
-                (t) => t !== timer,
-            )
-        }, 1400)
-
-        flashTimersRef.current.push(timer)
-    }, [board, errors])
+        flashPad(newlyComplete)
+    }, [board, errors, flashPad])
 
     return (
         <div className="number-pad">

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react"
+import { computeFull } from "../store/gameStore"
 
 interface NumberPadProps {
     onNumber: (n: number) => void
@@ -13,19 +14,6 @@ interface NumberPadProps {
     board: number[][]
     errors: Set<string>
     won: boolean
-}
-
-function computeFull(board: number[][], errors: Set<string>): Set<number> {
-    const counts = new Map<number, number>()
-    for (let r = 0; r < board.length; r++)
-        for (let c = 0; c < board[r].length; c++) {
-            const v = board[r][c]
-            if (v !== 0 && !errors.has(`${r},${c}`))
-                counts.set(v, (counts.get(v) ?? 0) + 1)
-        }
-    const full = new Set<number>()
-    for (const [n, count] of counts) if (count >= 9) full.add(n)
-    return full
 }
 
 export function NumberPad({

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,4 +1,5 @@
 import { useSnapshot } from "valtio"
+import { clipboardState } from "../store/clipboardStore"
 import { findState } from "../store/findStore"
 import {
     type CellPos,
@@ -21,13 +22,14 @@ function useStatusHint(): StatusHint | null {
     const hint = useSnapshot(hintState)
     const dataSnap = useSnapshot(gameData)
     const uiSnap = useSnapshot(gameUI)
+    const clipboard = useSnapshot(clipboardState)
     const hasLastOne =
         findLastOneCell(
             dataSnap.value.board as number[][],
             uiSnap.selected as CellPos | null,
         ) !== null
 
-    if (uiSnap.copied) {
+    if (clipboard.copied) {
         return {
             label: "COPIED",
             text: "Board copied to clipboard",

--- a/src/hooks/useFlashAnimation.test.ts
+++ b/src/hooks/useFlashAnimation.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { useFlashAnimation } from "./useFlashAnimation"
+
+describe("useFlashAnimation", () => {
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it("flash adds keys to the map", async () => {
+        vi.useFakeTimers()
+        const { result } = renderHook(() => useFlashAnimation<string>(700))
+        await act(async () => {
+            result.current.flash(["a", "b"])
+        })
+        expect(result.current.flashMap.has("a")).toBe(true)
+        expect(result.current.flashMap.has("b")).toBe(true)
+    })
+
+    it("keys are removed after duration elapses", async () => {
+        vi.useFakeTimers()
+        const { result } = renderHook(() => useFlashAnimation<string>(700))
+        await act(async () => {
+            result.current.flash(["a"])
+        })
+        await act(async () => {
+            vi.advanceTimersByTime(700)
+        })
+        expect(result.current.flashMap.has("a")).toBe(false)
+    })
+
+    it("overlapping flashes use reference counting to keep cell lit", async () => {
+        vi.useFakeTimers()
+        const { result } = renderHook(() => useFlashAnimation<string>(700))
+        await act(async () => {
+            result.current.flash(["a"])
+        })
+        await act(async () => {
+            result.current.flash(["a"])
+        })
+        // First timer fires — count goes from 2 to 1, key still present
+        await act(async () => {
+            vi.advanceTimersByTime(700)
+        })
+        expect(result.current.flashMap.has("a")).toBe(true)
+        // Second timer fires — count goes from 1 to 0, key removed
+        await act(async () => {
+            vi.advanceTimersByTime(700)
+        })
+        expect(result.current.flashMap.has("a")).toBe(false)
+    })
+
+    it("reset clears all flash state immediately", async () => {
+        vi.useFakeTimers()
+        const { result } = renderHook(() => useFlashAnimation<string>(700))
+        await act(async () => {
+            result.current.flash(["a", "b"])
+        })
+        await act(async () => {
+            result.current.reset()
+        })
+        expect(result.current.flashMap.size).toBe(0)
+    })
+
+    it("keys added again after reset flash correctly", async () => {
+        vi.useFakeTimers()
+        const { result } = renderHook(() => useFlashAnimation<string>(700))
+        await act(async () => {
+            result.current.flash(["a"])
+        })
+        await act(async () => {
+            result.current.reset()
+        })
+        await act(async () => {
+            result.current.flash(["a"])
+        })
+        expect(result.current.flashMap.has("a")).toBe(true)
+        await act(async () => {
+            vi.advanceTimersByTime(700)
+        })
+        expect(result.current.flashMap.has("a")).toBe(false)
+    })
+})

--- a/src/hooks/useFlashAnimation.ts
+++ b/src/hooks/useFlashAnimation.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+export interface FlashAnimation<K> {
+    flashMap: Map<K, number>
+    flash: (keys: Iterable<K>) => void
+    reset: () => void
+}
+
+export function useFlashAnimation<K>(duration: number): FlashAnimation<K> {
+    const [flashMap, setFlashMap] = useState(() => new Map<K, number>())
+    // flashMapRef mirrors state so flash() can read current counts synchronously.
+    const flashMapRef = useRef(new Map<K, number>())
+    const timersRef = useRef<ReturnType<typeof setTimeout>[]>([])
+
+    // Cancel all pending timers on unmount
+    useEffect(() => {
+        return () => {
+            for (const t of timersRef.current) clearTimeout(t)
+        }
+    }, [])
+
+    const flash = useCallback(
+        (keys: Iterable<K>) => {
+            const keyArr = [...keys]
+            if (keyArr.length === 0) return
+
+            // Compute stagger: the maximum existing reference count across all
+            // keys in this batch. A count of N means N timers are already queued
+            // for those keys, so we schedule after all of them by delaying an
+            // additional N * duration.
+            const maxExisting = keyArr.reduce(
+                (max, k) => Math.max(max, flashMapRef.current.get(k) ?? 0),
+                0,
+            )
+            const delay = duration + maxExisting * duration
+
+            // Increment counts immediately
+            const nextMap = new Map(flashMapRef.current)
+            for (const k of keyArr) nextMap.set(k, (nextMap.get(k) ?? 0) + 1)
+            flashMapRef.current = nextMap
+            setFlashMap(new Map(nextMap))
+
+            const timer = setTimeout(() => {
+                const after = new Map(flashMapRef.current)
+                for (const k of keyArr) {
+                    const count = after.get(k) ?? 0
+                    if (count <= 1) after.delete(k)
+                    else after.set(k, count - 1)
+                }
+                flashMapRef.current = after
+                setFlashMap(new Map(after))
+                timersRef.current = timersRef.current.filter((t) => t !== timer)
+            }, delay)
+
+            timersRef.current.push(timer)
+        },
+        [duration],
+    )
+
+    const reset = useCallback(() => {
+        for (const t of timersRef.current) clearTimeout(t)
+        timersRef.current = []
+        flashMapRef.current = new Map()
+        setFlashMap(new Map())
+    }, [])
+
+    return { flashMap, flash, reset }
+}

--- a/src/store/clipboardStore.ts
+++ b/src/store/clipboardStore.ts
@@ -1,0 +1,14 @@
+import { proxy } from "valtio"
+
+interface ClipboardState {
+    copied: boolean
+}
+
+export const clipboardState = proxy<ClipboardState>({ copied: false })
+
+export function setCopied() {
+    clipboardState.copied = true
+    setTimeout(() => {
+        clipboardState.copied = false
+    }, 2000)
+}

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -24,7 +24,6 @@ interface GameUI {
     difficulty: Difficulty
     elapsed: number
     notesMode: boolean
-    copied: boolean
 }
 
 function emptyNotes(): number[][][] {
@@ -52,7 +51,6 @@ function createInitialUI(
         difficulty,
         elapsed: 0,
         notesMode: false,
-        copied: false,
     }
 }
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -199,6 +199,9 @@ export function newGame(difficulty: Difficulty) {
     const data = createInitialData(puzzle)
     gameData.value.board = data.board
     gameData.value.notes = data.notes
+    // valtio-history has no public "reset history" API, so we directly clear the
+    // internal nodes array and reset the index. If valtio-history adds a public
+    // reset method in a future version, this should be updated to use it.
     gameData.history.nodes.splice(0)
     gameData.history.index = -1
     gameData.saveHistory()

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -126,6 +126,24 @@ export function moveSelectionToBlock(dr: number, dc: number) {
     }
 }
 
+function clearNotesAround(row: number, col: number, num: number) {
+    const boxR = Math.floor(row / 3) * 3
+    const boxC = Math.floor(col / 3) * 3
+    for (let i = 0; i < 9; i++) {
+        gameData.value.notes[row][i] = gameData.value.notes[row][i].filter(
+            (n) => n !== num,
+        )
+        gameData.value.notes[i][col] = gameData.value.notes[i][col].filter(
+            (n) => n !== num,
+        )
+        const br = boxR + Math.floor(i / 3)
+        const bc = boxC + (i % 3)
+        gameData.value.notes[br][bc] = gameData.value.notes[br][bc].filter(
+            (n) => n !== num,
+        )
+    }
+}
+
 export function placeNumber(num: number) {
     const sel = gameUI.selected
     if (!sel) return
@@ -135,21 +153,7 @@ export function placeNumber(num: number) {
     gameData.value.board[sel.row][sel.col] = num
     gameData.value.notes[sel.row][sel.col] = []
 
-    const boxR = Math.floor(sel.row / 3) * 3
-    const boxC = Math.floor(sel.col / 3) * 3
-    for (let i = 0; i < 9; i++) {
-        gameData.value.notes[sel.row][i] = gameData.value.notes[sel.row][
-            i
-        ].filter((n) => n !== num)
-        gameData.value.notes[i][sel.col] = gameData.value.notes[i][
-            sel.col
-        ].filter((n) => n !== num)
-        const br = boxR + Math.floor(i / 3)
-        const bc = boxC + (i % 3)
-        gameData.value.notes[br][bc] = gameData.value.notes[br][bc].filter(
-            (n) => n !== num,
-        )
-    }
+    clearNotesAround(sel.row, sel.col, num)
 
     gameData.saveHistory()
 }
@@ -281,21 +285,7 @@ export function fillLastDigit() {
     gameData.value.board[pos.row][pos.col] = num
     gameData.value.notes[pos.row][pos.col] = []
 
-    const boxR = Math.floor(pos.row / 3) * 3
-    const boxC = Math.floor(pos.col / 3) * 3
-    for (let i = 0; i < 9; i++) {
-        gameData.value.notes[pos.row][i] = gameData.value.notes[pos.row][
-            i
-        ].filter((n) => n !== num)
-        gameData.value.notes[i][pos.col] = gameData.value.notes[i][
-            pos.col
-        ].filter((n) => n !== num)
-        const br = boxR + Math.floor(i / 3)
-        const bc = boxC + (i % 3)
-        gameData.value.notes[br][bc] = gameData.value.notes[br][bc].filter(
-            (n) => n !== num,
-        )
-    }
+    clearNotesAround(pos.row, pos.col, num)
 
     gameData.saveHistory()
 }

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -94,6 +94,19 @@ export function computeWon(board: Board, solution: Board): boolean {
     )
 }
 
+export function computeFull(board: Board, errors: Set<string>): Set<number> {
+    const counts = new Map<number, number>()
+    for (let r = 0; r < 9; r++)
+        for (let c = 0; c < 9; c++) {
+            const v = board[r][c]
+            if (v !== 0 && !errors.has(`${r},${c}`))
+                counts.set(v, (counts.get(v) ?? 0) + 1)
+        }
+    const full = new Set<number>()
+    for (const [n, count] of counts) if (count >= 9) full.add(n)
+    return full
+}
+
 export function selectCell(pos: CellPos | null) {
     gameUI.selected = pos
 }

--- a/src/sudoku.ts
+++ b/src/sudoku.ts
@@ -32,6 +32,7 @@ function shuffle<T>(arr: T[]): T[] {
     return a
 }
 
+// NOTE: Mutates `board` in place. Callers that need the original intact must pass a copy.
 export function solve(board: Board, randomize = false): Board | null {
     for (let r = 0; r < 9; r++) {
         for (let c = 0; c < 9; c++) {

--- a/src/useKeyboard.ts
+++ b/src/useKeyboard.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react"
 import { boardToAscii } from "./export"
+import { setCopied } from "./store/clipboardStore"
 import { handleKey as findHandleKey } from "./store/findStore"
 import {
     clearCell,
@@ -108,10 +109,7 @@ export function useKeyboard() {
                 navigator.clipboard.writeText(
                     boardToAscii(gameData.value.board),
                 )
-                gameUI.copied = true
-                setTimeout(() => {
-                    gameUI.copied = false
-                }, 2000)
+                setCopied()
             } else if (e.key === "Escape") {
                 dismissHint()
             }


### PR DESCRIPTION
Closes #26

## Summary

- Add mutation comment to `solve()` in `sudoku.ts` — the function modifies its board argument in place with no indication in the signature
- Add comment explaining direct valtio-history internals access in `newGame()` — no public reset API exists
- Extract `clearNotesAround(row, col, num)` helper — removes a 15-line duplicated block from `placeNumber` and `fillLastDigit`
- Export `computeFull` from `gameStore` — `Board.tsx` now uses it instead of duplicating the logic inline; local copy removed from `NumberPad.tsx`
- Extract `useFlashAnimation<K>` hook with 5 tests — replaces ~50 lines of identical reference-counted flash animation logic in both `Board.tsx` and `NumberPad.tsx`
- Create `clipboardStore` — moves `copied` boolean out of `GameUI` into a dedicated proxy; updates `useKeyboard.ts` and `StatusBar.tsx` accordingly