### PR TITLE
Dark/light/system theme support with settings panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A fully playable browser-based Sudoku with three difficulty levels, pencil notes
 - **Status bar** — Contextual shortcut hints so you don't have to memorize everything
 - **Win detection** — Fill it all in correctly and get a satisfying overlay
 - **Completion animations** — Blue flash on cells when a row, column, or box is completed; matching blue flash on the number pad button when all 9 of a digit are placed
+- **Dark / Light / System theme** — Click the ⚙ gear icon (top-right) to switch themes; system mode follows your OS preference and persists across sessions
 
 ## Tech Stack
 
@@ -53,10 +54,12 @@ src/
   store/
     gameStore.ts      — Two Valtio proxies: board data (with undo/redo) and UI state
     jumpStore.ts      — Jump mode state machine
+    themeStore.ts     — Theme state (system/light/dark), localStorage persistence
   components/
     Board.tsx         — 9x9 grid with highlighting and overlay support
     Cell.tsx          — A single cell (values, notes, overlays, or emptiness)
     NumberPad.tsx     — Number buttons, notes toggle, erase, undo/redo
+    SettingsPanel.tsx — Fixed gear button + theme picker panel
     StatusBar.tsx     — Contextual shortcut hints
   index.css           — All the styles, one file, no regrets
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "vcsudoku",
             "version": "0.0.0",
             "dependencies": {
+                "lucide-react": "^0.576.0",
                 "react": "^19.2.0",
                 "react-dom": "^19.2.0",
                 "valtio": "^2.3.0",
@@ -2515,6 +2516,15 @@
             "license": "ISC",
             "dependencies": {
                 "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/lucide-react": {
+            "version": "0.576.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.576.0.tgz",
+            "integrity": "sha512-koNxU14BXrxUfZQ9cUaP0ES1uyPZKYDjk31FQZB6dQ/x+tXk979sVAn9ppZ/pVeJJyOxVM8j1E+8QEuSc02Vug==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "test": "vitest run"
     },
     "dependencies": {
+        "lucide-react": "^0.576.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "valtio": "^2.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useSnapshot } from "valtio"
 import { Board } from "./components/Board"
 import { NumberPad } from "./components/NumberPad"
+import { SettingsPanel } from "./components/SettingsPanel"
 import { StatusBar } from "./components/StatusBar"
 import { showHint } from "./store/hintStore"
 import { getOverlay, jumpState } from "./store/jumpStore"
@@ -18,13 +19,16 @@ function App() {
     const jump = useSnapshot(jumpState)
 
     return (
-        <div className="app">
-            <h1>Sudoku</h1>
+        <>
+            <SettingsPanel />
+            <div className="app">
+                <h1>Sudoku</h1>
 
-            <div className="toolbar">
-                <div className="difficulty-group">
-                    {(["easy", "medium", "hard", "expert"] as Difficulty[]).map(
-                        (d) => (
+                <div className="toolbar">
+                    <div className="difficulty-group">
+                        {(
+                            ["easy", "medium", "hard", "expert"] as Difficulty[]
+                        ).map((d) => (
                             <button
                                 type="button"
                                 key={d}
@@ -33,56 +37,58 @@ function App() {
                             >
                                 {d.charAt(0).toUpperCase() + d.slice(1)}
                             </button>
-                        ),
-                    )}
-                </div>
-                <div className="timer">{formatTime(game.elapsed)}</div>
-            </div>
-
-            <Board
-                board={game.board}
-                initial={game.initial}
-                selected={game.selected}
-                errors={game.errors}
-                notes={game.notes}
-                onSelectCell={game.selectCell}
-                overlay={jump.active ? getOverlay : undefined}
-            />
-
-            <NumberPad
-                onNumber={(n) =>
-                    game.notesMode ? game.toggleNote(n) : game.placeNumber(n)
-                }
-                onClear={game.clearCell}
-                onUndo={game.undo}
-                onRedo={game.redo}
-                onHint={showHint}
-                undoDisabled={!game.canUndo}
-                redoDisabled={!game.canRedo}
-                notesMode={game.notesMode}
-                onToggleNotesMode={game.toggleNotesMode}
-                board={game.board}
-                errors={game.errors}
-                won={game.won}
-            />
-
-            <StatusBar />
-
-            {game.won && (
-                <div className="win-overlay">
-                    <div className="win-message">
-                        <h2>You Win!</h2>
-                        <p>Completed in {formatTime(game.elapsed)}</p>
-                        <button
-                            type="button"
-                            onClick={() => game.newGame(game.difficulty)}
-                        >
-                            Play Again
-                        </button>
+                        ))}
                     </div>
+                    <div className="timer">{formatTime(game.elapsed)}</div>
                 </div>
-            )}
-        </div>
+
+                <Board
+                    board={game.board}
+                    initial={game.initial}
+                    selected={game.selected}
+                    errors={game.errors}
+                    notes={game.notes}
+                    onSelectCell={game.selectCell}
+                    overlay={jump.active ? getOverlay : undefined}
+                />
+
+                <NumberPad
+                    onNumber={(n) =>
+                        game.notesMode
+                            ? game.toggleNote(n)
+                            : game.placeNumber(n)
+                    }
+                    onClear={game.clearCell}
+                    onUndo={game.undo}
+                    onRedo={game.redo}
+                    onHint={showHint}
+                    undoDisabled={!game.canUndo}
+                    redoDisabled={!game.canRedo}
+                    notesMode={game.notesMode}
+                    onToggleNotesMode={game.toggleNotesMode}
+                    board={game.board}
+                    errors={game.errors}
+                    won={game.won}
+                />
+
+                <StatusBar />
+
+                {game.won && (
+                    <div className="win-overlay">
+                        <div className="win-message">
+                            <h2>You Win!</h2>
+                            <p>Completed in {formatTime(game.elapsed)}</p>
+                            <button
+                                type="button"
+                                onClick={() => game.newGame(game.difficulty)}
+                            >
+                                Play Again
+                            </button>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </>
     )
 }
 

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { mockSetTheme, mockThemeState } = vi.hoisted(() => {
+    const mockThemeState = { theme: "system" }
+    const mockSetTheme = vi.fn()
+    return { mockThemeState, mockSetTheme }
+})
+
+vi.mock("../store/themeStore", () => ({
+    themeState: mockThemeState,
+    setTheme: mockSetTheme,
+    THEME_OPTIONS: [
+        { label: "System", value: "system" },
+        { label: "Light", value: "light" },
+        { label: "Dark", value: "dark" },
+    ],
+}))
+
+vi.mock("valtio", () => ({
+    useSnapshot: vi.fn((state) => state),
+}))
+
+import { SettingsPanel } from "./SettingsPanel"
+
+afterEach(cleanup)
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    mockThemeState.theme = "system"
+})
+
+describe("SettingsPanel", () => {
+    it("renders gear button", () => {
+        render(<SettingsPanel />)
+        expect(screen.getByRole("button", { name: "Settings" })).toBeDefined()
+    })
+
+    it("panel is hidden by default", () => {
+        render(<SettingsPanel />)
+        expect(screen.queryByText("System")).toBeNull()
+    })
+
+    it("clicking gear button opens the panel with all options", () => {
+        render(<SettingsPanel />)
+        fireEvent.click(screen.getByRole("button", { name: "Settings" }))
+        expect(screen.getByText("System")).toBeDefined()
+        expect(screen.getByText("Light")).toBeDefined()
+        expect(screen.getByText("Dark")).toBeDefined()
+    })
+
+    it("clicking a theme option calls setTheme", () => {
+        render(<SettingsPanel />)
+        fireEvent.click(screen.getByRole("button", { name: "Settings" }))
+        fireEvent.click(screen.getByRole("button", { name: "Dark" }))
+        expect(mockSetTheme).toHaveBeenCalledWith("dark")
+    })
+
+    it("active theme option has theme-option-active class", () => {
+        mockThemeState.theme = "dark"
+        render(<SettingsPanel />)
+        fireEvent.click(screen.getByRole("button", { name: "Settings" }))
+        expect(screen.getByRole("button", { name: "Dark" }).className).toContain(
+            "theme-option-active",
+        )
+        expect(screen.getByRole("button", { name: "Light" }).className).not.toContain(
+            "theme-option-active",
+        )
+    })
+
+    it("clicking outside closes the panel", () => {
+        render(<SettingsPanel />)
+        fireEvent.click(screen.getByRole("button", { name: "Settings" }))
+        expect(screen.getByText("System")).toBeDefined()
+        fireEvent.mouseDown(document.body)
+        expect(screen.queryByText("System")).toBeNull()
+    })
+
+    it("clicking gear again closes the panel", () => {
+        render(<SettingsPanel />)
+        fireEvent.click(screen.getByRole("button", { name: "Settings" }))
+        expect(screen.getByText("System")).toBeDefined()
+        fireEvent.click(screen.getByRole("button", { name: "Settings" }))
+        expect(screen.queryByText("System")).toBeNull()
+    })
+})

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -60,12 +60,12 @@ describe("SettingsPanel", () => {
         mockThemeState.theme = "dark"
         render(<SettingsPanel />)
         fireEvent.click(screen.getByRole("button", { name: "Settings" }))
-        expect(screen.getByRole("button", { name: "Dark" }).className).toContain(
-            "theme-option-active",
-        )
-        expect(screen.getByRole("button", { name: "Light" }).className).not.toContain(
-            "theme-option-active",
-        )
+        expect(
+            screen.getByRole("button", { name: "Dark" }).className,
+        ).toContain("theme-option-active")
+        expect(
+            screen.getByRole("button", { name: "Light" }).className,
+        ).not.toContain("theme-option-active")
     })
 
     it("clicking outside closes the panel", () => {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from "react"
+import { useSnapshot } from "valtio"
+import { setTheme, type Theme, themeState } from "../store/themeStore"
+
+export function SettingsPanel() {
+    const [open, setOpen] = useState(false)
+    const panelRef = useRef<HTMLDivElement>(null)
+    const snap = useSnapshot(themeState)
+
+    useEffect(() => {
+        if (!open) return
+        function handleClick(e: MouseEvent) {
+            if (
+                panelRef.current &&
+                !panelRef.current.contains(e.target as Node)
+            ) {
+                setOpen(false)
+            }
+        }
+        document.addEventListener("mousedown", handleClick)
+        return () => document.removeEventListener("mousedown", handleClick)
+    }, [open])
+
+    const options: { label: string; value: Theme }[] = [
+        { label: "System", value: "system" },
+        { label: "Light", value: "light" },
+        { label: "Dark", value: "dark" },
+    ]
+
+    return (
+        <div ref={panelRef}>
+            <button
+                type="button"
+                className="settings-gear"
+                onClick={() => setOpen((v) => !v)}
+                aria-label="Settings"
+            >
+                ⚙
+            </button>
+            {open && (
+                <div className="settings-panel">
+                    <h3>Theme</h3>
+                    <div className="theme-options">
+                        {options.map(({ label, value }) => (
+                            <button
+                                type="button"
+                                key={value}
+                                className={`theme-option${snap.theme === value ? " theme-option-active" : ""}`}
+                                onClick={() => setTheme(value)}
+                            >
+                                {label}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 import { Settings } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useSnapshot } from "valtio"
-import { setTheme, type Theme, themeState } from "../store/themeStore"
+import { setTheme, THEME_OPTIONS, themeState } from "../store/themeStore"
 
 export function SettingsPanel() {
     const [open, setOpen] = useState(false)
@@ -22,12 +22,6 @@ export function SettingsPanel() {
         return () => document.removeEventListener("mousedown", handleClick)
     }, [open])
 
-    const options: { label: string; value: Theme }[] = [
-        { label: "System", value: "system" },
-        { label: "Light", value: "light" },
-        { label: "Dark", value: "dark" },
-    ]
-
     return (
         <div ref={panelRef}>
             <button
@@ -42,7 +36,7 @@ export function SettingsPanel() {
                 <div className="settings-panel">
                     <h3>Theme</h3>
                     <div className="theme-options">
-                        {options.map(({ label, value }) => (
+                        {THEME_OPTIONS.map(({ label, value }) => (
                             <button
                                 type="button"
                                 key={value}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,3 +1,4 @@
+import { Settings } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useSnapshot } from "valtio"
 import { setTheme, type Theme, themeState } from "../store/themeStore"
@@ -35,7 +36,7 @@ export function SettingsPanel() {
                 onClick={() => setOpen((v) => !v)}
                 aria-label="Settings"
             >
-                ⚙
+                <Settings size={16} aria-hidden="true" />
             </button>
             {open && (
                 <div className="settings-panel">

--- a/src/index.css
+++ b/src/index.css
@@ -517,7 +517,6 @@ h1 {
     border-radius: var(--radius-btn);
     background: var(--color-surface);
     color: var(--color-text-muted);
-    font-size: 1.1rem;
     cursor: pointer;
     display: flex;
     align-items: center;

--- a/src/index.css
+++ b/src/index.css
@@ -70,8 +70,8 @@ button:focus-visible {
     --color-bg: #121212;
     --color-surface: #1e1e2e;
     --color-surface-raised: #2a2a3a;
-    --color-board-bg: #0d1117;
-    --color-cell: #1c1c2e;
+    --color-board-bg: #2d3548;
+    --color-cell: #1c2030;
     --color-selected: #1e3a5c;
     --color-highlighted: #1a2d3d;
     --color-same-number: #252550;
@@ -81,9 +81,9 @@ button:focus-visible {
     --color-text-subtle: #6e7681;
     --color-text-secondary: #b0bec5;
     --color-text-faint: #585f69;
-    --color-text-player: #79b8ff;
-    --color-text-initial: #e6edf3;
-    --color-text-error: #ffa0a0;
+    --color-text-player: #5a8fc5;
+    --color-text-initial: #8a9aaa;
+    --color-text-error: #e08080;
     --color-text-notes: #5d7a8f;
     --color-text-dim: #3d5060;
     --color-border: #30363d;

--- a/src/index.css
+++ b/src/index.css
@@ -15,20 +15,83 @@ button:focus-visible {
 }
 
 :root {
+    /* Layout */
     --cell-size: min(10vw, 56px);
     --board-gap: 1px;
-    --box-border: 2px;
+    --border-box: 2px;
+
+    /* Shape */
+    --radius-cell: 0px;
+    --radius-btn: 6px;
+    --radius-panel: 12px;
+
+    /* Backgrounds */
     --color-bg: #f5f5f5;
+    --color-surface: #ffffff;
+    --color-surface-raised: #f0f0f0;
     --color-board-bg: #344861;
-    --color-cell: #fff;
+    --color-cell: #ffffff;
+
+    /* Cell states */
     --color-selected: #bbdefb;
     --color-highlighted: #e3f2fd;
     --color-same-number: #c5cae9;
     --color-error: #ffcdd2;
-    --color-error-text: #c62828;
-    --color-initial: #344861;
-    --color-player: #2196f3;
+
+    /* Text */
+    --color-text: #344861;
+    --color-text-muted: #555555;
+    --color-text-subtle: #666666;
+    --color-text-secondary: #444444;
+    --color-text-faint: #888888;
+    --color-text-notes: #7b8ba3;
+    --color-text-dim: #adb5bd;
+    --color-text-on-primary: #ffffff;
+    --color-text-initial: #344861;
+    --color-text-player: #2196f3;
+    --color-text-error: #c62828;
+
+    /* Borders */
+    --color-border: #cccccc;
+    --color-border-shadow: #bbbbbb;
+
+    /* Accents */
     --color-primary: #1976d2;
+    --color-primary-hover: #1565c0;
+    --color-hint: #f57f17;
+    --color-hint-border: #f9a825;
+    --color-jump-label: #fdd835;
+    --color-jump-text: #000000;
+    --color-overlay: rgba(0, 0, 0, 0.5);
+}
+
+/* Dark theme overrides */
+[data-theme="dark"] {
+    --color-bg: #121212;
+    --color-surface: #1e1e2e;
+    --color-surface-raised: #2a2a3a;
+    --color-board-bg: #0d1117;
+    --color-cell: #1c1c2e;
+    --color-selected: #1e3a5c;
+    --color-highlighted: #1a2d3d;
+    --color-same-number: #252550;
+    --color-error: #4a1a1a;
+    --color-text: #c9d1d9;
+    --color-text-muted: #8b949e;
+    --color-text-subtle: #6e7681;
+    --color-text-secondary: #b0bec5;
+    --color-text-faint: #585f69;
+    --color-text-player: #79b8ff;
+    --color-text-initial: #e6edf3;
+    --color-text-error: #ffa0a0;
+    --color-text-notes: #5d7a8f;
+    --color-text-dim: #3d5060;
+    --color-border: #30363d;
+    --color-border-shadow: #1c2128;
+    --color-primary: #388bfd;
+    --color-primary-hover: #1f6feb;
+    --color-hint: #e3b341;
+    --color-hint-border: #d4a017;
 }
 
 body {
@@ -50,7 +113,7 @@ body {
 
 h1 {
     font-size: 1.8rem;
-    color: var(--color-initial);
+    color: var(--color-text);
     margin-bottom: 16px;
 }
 
@@ -65,7 +128,7 @@ h1 {
         9 +
         var(--board-gap) *
         8 +
-        var(--box-border) *
+        var(--border-box) *
         4
     );
     margin-bottom: 16px;
@@ -78,12 +141,12 @@ h1 {
 
 .diff-btn {
     padding: 6px 14px;
-    border: 1px solid #ccc;
-    border-radius: 6px;
-    background: #fff;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-btn);
+    background: var(--color-surface);
     cursor: pointer;
     font-size: 0.85rem;
-    color: #555;
+    color: var(--color-text-muted);
     transition: all 0.15s;
 }
 
@@ -94,14 +157,14 @@ h1 {
 
 .diff-btn.diff-active {
     background: var(--color-primary);
-    color: #fff;
+    color: var(--color-text-on-primary);
     border-color: var(--color-primary);
 }
 
 .timer {
     font-size: 1.2rem;
     font-variant-numeric: tabular-nums;
-    color: #555;
+    color: var(--color-text-muted);
     font-weight: 500;
 }
 
@@ -112,19 +175,19 @@ h1 {
     grid-template-rows: repeat(9, var(--cell-size));
     gap: var(--board-gap);
     background: var(--color-board-bg);
-    padding: var(--box-border);
+    padding: var(--border-box);
     user-select: none;
 }
 
 /* Thicker borders for 3x3 boxes via extra gap on specific cells */
 .board > .cell:nth-child(9n + 4),
 .board > .cell:nth-child(9n + 7) {
-    margin-left: var(--box-border);
+    margin-left: var(--border-box);
 }
 
 .board > .cell:nth-child(n + 28):nth-child(-n + 36),
 .board > .cell:nth-child(n + 55):nth-child(-n + 63) {
-    margin-top: var(--box-border);
+    margin-top: var(--border-box);
 }
 
 /* Cells */
@@ -136,18 +199,18 @@ h1 {
     background: var(--color-cell);
     font-size: calc(var(--cell-size) * 0.45);
     cursor: pointer;
-    color: var(--color-player);
+    color: var(--color-text-player);
     font-weight: 400;
     transition: background 0.1s;
 }
 
 .cell-initial {
-    color: var(--color-initial);
+    color: var(--color-text-initial);
     font-weight: 700;
 }
 
 .cell-digit-complete {
-    color: #adb5bd;
+    color: var(--color-text-dim);
 }
 
 @keyframes line-complete-flash {
@@ -181,7 +244,7 @@ h1 {
 }
 
 .cell-error {
-    color: var(--color-error-text);
+    color: var(--color-text-error);
     background: var(--color-error);
 }
 
@@ -200,7 +263,7 @@ h1 {
     align-items: center;
     justify-content: center;
     font-size: calc(var(--cell-size) * 0.22);
-    color: #7b8ba3;
+    color: var(--color-text-notes);
     font-weight: 400;
     line-height: 1;
 }
@@ -217,7 +280,7 @@ h1 {
         9 +
         var(--board-gap) *
         8 +
-        var(--box-border) *
+        var(--border-box) *
         4
     );
     width: 100%;
@@ -227,9 +290,9 @@ h1 {
     position: relative;
     width: calc(var(--cell-size) * 0.85);
     height: calc(var(--cell-size) * 0.85);
-    border: 1px solid #ccc;
-    border-radius: 8px;
-    background: #fff;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-btn);
+    background: var(--color-surface);
     font-size: calc(var(--cell-size) * 0.4);
     cursor: pointer;
     color: var(--color-primary);
@@ -277,12 +340,12 @@ h1 {
     width: auto;
     padding: 0 16px;
     font-size: 0.85rem;
-    color: #555;
+    color: var(--color-text-muted);
 }
 
 .notes-btn.notes-active {
     background: var(--color-primary);
-    color: #fff;
+    color: var(--color-text-on-primary);
     border-color: var(--color-primary);
 }
 
@@ -291,29 +354,29 @@ h1 {
     width: auto;
     padding: 0 16px;
     font-size: 0.85rem;
-    color: #555;
+    color: var(--color-text-muted);
 }
 
 .erase-btn {
     width: auto;
     padding: 0 16px;
     font-size: 0.85rem;
-    color: #c62828;
+    color: var(--color-text-error);
 }
 
 .hint-btn {
     width: auto;
     padding: 0 16px;
     font-size: 0.85rem;
-    color: #f57f17;
-    border-color: #f9a825;
+    color: var(--color-hint);
+    border-color: var(--color-hint-border);
 }
 
 /* Win overlay */
 .win-overlay {
     position: fixed;
     inset: 0;
-    background: rgba(0, 0, 0, 0.5);
+    background: var(--color-overlay);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -321,36 +384,36 @@ h1 {
 }
 
 .win-message {
-    background: #fff;
+    background: var(--color-surface);
     padding: 40px;
-    border-radius: 16px;
+    border-radius: var(--radius-panel);
     text-align: center;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
 }
 
 .win-message h2 {
     font-size: 1.8rem;
-    color: var(--color-initial);
+    color: var(--color-text);
     margin-bottom: 8px;
 }
 
 .win-message p {
-    color: #666;
+    color: var(--color-text-subtle);
     margin-bottom: 20px;
 }
 
 .win-message button {
     padding: 10px 28px;
     background: var(--color-primary);
-    color: #fff;
+    color: var(--color-text-on-primary);
     border: none;
-    border-radius: 8px;
+    border-radius: var(--radius-btn);
     font-size: 1rem;
     cursor: pointer;
 }
 
 .win-message button:hover {
-    background: #1565c0;
+    background: var(--color-primary-hover);
 }
 
 /* Jump mode overlay */
@@ -369,8 +432,8 @@ h1 {
     width: calc(var(--cell-size) * 0.33);
     height: calc(var(--cell-size) * 0.33);
     border-radius: 2px;
-    background: #fdd835;
-    color: #000;
+    background: var(--color-jump-label);
+    color: var(--color-jump-text);
     font-size: calc(var(--cell-size) * 0.18);
     font-weight: 700;
     line-height: 1;
@@ -394,7 +457,7 @@ h1 {
     border: none;
     border-radius: 24px;
     font-size: 0.85rem;
-    color: #555;
+    color: var(--color-text-muted);
     box-shadow: none;
     animation: status-fade-in 0.15s ease-out;
 }
@@ -403,7 +466,7 @@ h1 {
     display: inline-block;
     padding: 2px 10px;
     background: var(--color-primary);
-    color: #fff;
+    color: var(--color-text-on-primary);
     border-radius: 12px;
     font-weight: 700;
     font-size: 0.75rem;
@@ -411,25 +474,25 @@ h1 {
 }
 
 .status-bar-text {
-    color: #444;
+    color: var(--color-text-secondary);
 }
 
 .status-bar-shortcut {
-    color: #888;
+    color: var(--color-text-faint);
     font-size: 0.8rem;
 }
 
 .status-bar-shortcut kbd {
     display: inline-block;
     padding: 1px 6px;
-    background: #f0f0f0;
-    border: 1px solid #ccc;
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-border);
     border-radius: 4px;
     font-family: system-ui, -apple-system, sans-serif;
     font-size: 0.75rem;
     font-weight: 600;
-    color: #444;
-    box-shadow: 0 1px 0 #bbb;
+    color: var(--color-text-secondary);
+    box-shadow: 0 1px 0 var(--color-border-shadow);
 }
 
 @keyframes status-fade-in {
@@ -441,4 +504,80 @@ h1 {
         opacity: 1;
         transform: translateY(0);
     }
+}
+
+/* Settings panel */
+.settings-gear {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    width: 36px;
+    height: 36px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-btn);
+    background: var(--color-surface);
+    color: var(--color-text-muted);
+    font-size: 1.1rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    transition: all 0.15s;
+}
+
+.settings-gear:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.settings-panel {
+    position: fixed;
+    top: 60px;
+    right: 16px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-panel);
+    padding: 16px;
+    z-index: 99;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+    min-width: 180px;
+}
+
+.settings-panel h3 {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 10px;
+}
+
+.theme-options {
+    display: flex;
+    gap: 6px;
+}
+
+.theme-option {
+    flex: 1;
+    padding: 6px 10px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-btn);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.15s;
+    text-align: center;
+}
+
+.theme-option:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.theme-option-active {
+    background: var(--color-primary);
+    color: var(--color-text-on-primary);
+    border-color: var(--color-primary);
 }

--- a/src/store/themeStore.test.ts
+++ b/src/store/themeStore.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+function mockMatchMedia(prefersDark: boolean) {
+    Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: vi.fn().mockReturnValue({
+            matches: prefersDark,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        }),
+    })
+}
+
+beforeEach(() => {
+    vi.resetModules()
+    localStorage.clear()
+    document.documentElement.removeAttribute("data-theme")
+    mockMatchMedia(false)
+})
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe("themeStore", () => {
+    it("default theme is 'system' when localStorage is empty", async () => {
+        const { themeState } = await import("./themeStore")
+        expect(themeState.theme).toBe("system")
+    })
+
+    it("setTheme('dark') sets data-theme to 'dark'", async () => {
+        const { setTheme } = await import("./themeStore")
+        setTheme("dark")
+        expect(document.documentElement.dataset.theme).toBe("dark")
+    })
+
+    it("setTheme('light') sets data-theme to 'light'", async () => {
+        const { setTheme } = await import("./themeStore")
+        setTheme("light")
+        expect(document.documentElement.dataset.theme).toBe("light")
+    })
+
+    it("setTheme('system') resolves to 'light' when OS prefers light", async () => {
+        mockMatchMedia(false)
+        const { setTheme } = await import("./themeStore")
+        setTheme("system")
+        expect(document.documentElement.dataset.theme).toBe("light")
+    })
+
+    it("setTheme('system') resolves to 'dark' when OS prefers dark", async () => {
+        mockMatchMedia(true)
+        const { setTheme } = await import("./themeStore")
+        setTheme("system")
+        expect(document.documentElement.dataset.theme).toBe("dark")
+    })
+
+    it("setTheme persists to localStorage", async () => {
+        const { setTheme } = await import("./themeStore")
+        setTheme("dark")
+        expect(localStorage.getItem("vcsudoku-theme")).toBe("dark")
+
+        setTheme("light")
+        expect(localStorage.getItem("vcsudoku-theme")).toBe("light")
+
+        setTheme("system")
+        expect(localStorage.getItem("vcsudoku-theme")).toBe("system")
+    })
+
+    it("loads persisted theme from localStorage on module init", async () => {
+        localStorage.setItem("vcsudoku-theme", "dark")
+        const { themeState } = await import("./themeStore")
+        expect(themeState.theme).toBe("dark")
+        expect(document.documentElement.dataset.theme).toBe("dark")
+    })
+})

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -2,6 +2,12 @@ import { proxy } from "valtio"
 
 export type Theme = "system" | "light" | "dark"
 
+export const THEME_OPTIONS: { label: string; value: Theme }[] = [
+    { label: "System", value: "system" },
+    { label: "Light", value: "light" },
+    { label: "Dark", value: "dark" },
+]
+
 const STORAGE_KEY = "vcsudoku-theme"
 
 interface ThemeState {

--- a/src/store/themeStore.ts
+++ b/src/store/themeStore.ts
@@ -1,0 +1,51 @@
+import { proxy } from "valtio"
+
+export type Theme = "system" | "light" | "dark"
+
+const STORAGE_KEY = "vcsudoku-theme"
+
+interface ThemeState {
+    theme: Theme
+}
+
+function loadTheme(): Theme {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === "light" || stored === "dark" || stored === "system") {
+        return stored
+    }
+    return "system"
+}
+
+export function applyTheme(theme: Theme): void {
+    let resolved: "light" | "dark"
+    if (theme === "system") {
+        resolved = window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light"
+    } else {
+        resolved = theme
+    }
+    document.documentElement.dataset.theme = resolved
+}
+
+export function setTheme(theme: Theme): void {
+    themeState.theme = theme
+    localStorage.setItem(STORAGE_KEY, theme)
+    applyTheme(theme)
+}
+
+export const themeState = proxy<ThemeState>({
+    theme: loadTheme(),
+})
+
+// Re-apply when OS preference changes while in system mode
+window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", () => {
+        if (themeState.theme === "system") {
+            applyTheme("system")
+        }
+    })
+
+// Apply on module load
+applyTheme(themeState.theme)


### PR DESCRIPTION
Closes #28

## Summary
- Refactored all CSS hardcoded colors to semantic CSS custom properties; renamed 4 existing variables for consistency; added shape variables (`--radius-cell`, `--radius-btn`, `--radius-panel`)
- Added `[data-theme="dark"]` overrides for full dark theme
- Created `themeStore.ts` (Valtio proxy, localStorage persistence under `vcsudoku-theme`, OS media query listener)
- Created `SettingsPanel.tsx` — fixed ⚙ gear button (top-right) with System / Light / Dark pill picker; click-outside closes
- Added tests for themeStore (7 tests covering default, persistence, dark/light/system resolution)