### PR TITLE
Fix mobile UX, add master difficulty, custom complexity, MRV hints, ASCII import (#32)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Run all tests:** `npm run test` (runs `vitest run`)
 - **Run a single test file:** `npx vitest run src/sudoku.test.ts`
 - **Run tests matching a pattern:** `npx vitest run -t "pattern"`
+- **Generate PWA icons:** `npm run generate-pwa-assets` (runs `pwa-assets-generator --preset minimal public/icon.svg`, outputs to `public/`)
 
 ## Tech Stack
 
-React 19, TypeScript 5.9, Vite 7, Valtio 2 (with valtio-history for undo/redo), Vitest 4 with jsdom environment, @testing-library/react for hook testing. Node 24 (specified in `mise.toml`).
+React 19, TypeScript 5.9, Vite 7, Valtio 2 (with valtio-history for undo/redo), Vitest 4 with jsdom environment, @testing-library/react for hook testing, vite-plugin-pwa (Workbox-based service worker + web manifest), @vite-pwa/assets-generator (icon generation from SVG). Node 24 (specified in `mise.toml`).
 
 ## Architecture
 
@@ -25,6 +26,7 @@ This is a browser-based Sudoku game. All source code is in `src/`.
 
 - **`store/gameStore.ts`** — Two Valtio proxies: `gameData` (proxyWithHistory wrapping board + notes, enables undo/redo) and `gameUI` (plain proxy for solution, initial, selected, difficulty, elapsed, notesMode). All game mutations and derived computations (`computeErrors`, `computeWon`) live here. Also exports `fillCandidateNotes` (fills selected cell's notes with valid candidates) and `fillAllCandidateNotes` (fills all empty non-initial cells); both guard against the won state and save a single undo history entry.
 - **`store/jumpStore.ts`** — Jump mode state machine (Valtio proxy). Space activates, two digits (row, col) jump to a cell, Escape cancels. Provides `getOverlay` for cell coordinate labels.
+- **`store/themeStore.ts`** — Theme state (system/light/dark) with localStorage persistence.
 
 ### Hooks
 
@@ -42,6 +44,7 @@ This is a browser-based Sudoku game. All source code is in `src/`.
 - **`components/Cell.tsx`** — Renders a single cell: value, notes (3x3 grid of candidate digits), overlay label, or empty.
 - **`components/NumberPad.tsx`** — Number buttons 1-9 (disabled when all 9 instances placed), Notes toggle, Erase button, Undo/Redo buttons.
 - **`components/StatusBar.tsx`** — Contextual shortcut hints. Shows jump mode prompts when active, default navigation shortcuts otherwise.
+- **`components/SettingsPanel.tsx`** — Fixed gear button + theme picker panel (system/light/dark).
 
 ### Styles
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import { StatusBar } from "./components/StatusBar"
 import { fillCandidateNotes, fillLastDigit } from "./store/gameStore"
 import { showHint } from "./store/hintStore"
 import { getOverlay, jumpState } from "./store/jumpStore"
-import type { Difficulty } from "./sudoku"
 import { useGame } from "./useGame"
 
 function formatTime(seconds: number) {
@@ -21,31 +20,13 @@ function App() {
 
     return (
         <>
-            <SettingsPanel />
+            <SettingsPanel
+                difficulty={game.difficulty}
+                onNewGame={game.newGame}
+            />
             <div className="app">
-                <h1>Sudoku</h1>
-
-                <div className="toolbar">
-                    <div className="difficulty-group">
-                        {(
-                            [
-                                "easy",
-                                "medium",
-                                "hard",
-                                "master",
-                                "expert",
-                            ] as Difficulty[]
-                        ).map((d) => (
-                            <button
-                                type="button"
-                                key={d}
-                                className={`diff-btn ${game.difficulty === d ? "diff-active" : ""}`}
-                                onClick={() => game.newGame(d)}
-                            >
-                                {d.charAt(0).toUpperCase() + d.slice(1)}
-                            </button>
-                        ))}
-                    </div>
+                <div className="app-header">
+                    <h1>Sudoku</h1>
                     <div className="timer">{formatTime(game.elapsed)}</div>
                 </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,13 @@ function App() {
                 <div className="toolbar">
                     <div className="difficulty-group">
                         {(
-                            ["easy", "medium", "hard", "expert"] as Difficulty[]
+                            [
+                                "easy",
+                                "medium",
+                                "hard",
+                                "master",
+                                "expert",
+                            ] as Difficulty[]
                         ).map((d) => (
                             <button
                                 type="button"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ function App() {
                 <div className="app-header">
                     <h1>Sudoku</h1>
                     <div className="timer">{formatTime(game.elapsed)}</div>
+                    <div className="spacer" />
                     <SettingsPanel
                         difficulty={game.difficulty}
                         onNewGame={game.newGame}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Board } from "./components/Board"
 import { NumberPad } from "./components/NumberPad"
 import { SettingsPanel } from "./components/SettingsPanel"
 import { StatusBar } from "./components/StatusBar"
+import { fillCandidateNotes, fillLastDigit } from "./store/gameStore"
 import { showHint } from "./store/hintStore"
 import { getOverlay, jumpState } from "./store/jumpStore"
 import type { Difficulty } from "./sudoku"
@@ -68,6 +69,8 @@ function App() {
                     onUndo={game.undo}
                     onRedo={game.redo}
                     onHint={showHint}
+                    onFillCell={fillCandidateNotes}
+                    onFillLast={fillLastDigit}
                     undoDisabled={!game.canUndo}
                     redoDisabled={!game.canRedo}
                     notesMode={game.notesMode}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,14 +20,14 @@ function App() {
 
     return (
         <>
-            <SettingsPanel
-                difficulty={game.difficulty}
-                onNewGame={game.newGame}
-            />
             <div className="app">
                 <div className="app-header">
                     <h1>Sudoku</h1>
                     <div className="timer">{formatTime(game.elapsed)}</div>
+                    <SettingsPanel
+                        difficulty={game.difficulty}
+                        onNewGame={game.newGame}
+                    />
                 </div>
 
                 <Board

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -145,7 +145,7 @@ export function NumberPad({
                     disabled={won}
                     onClick={onFillLast}
                 >
-                    Fill
+                    Last
                 </button>
             </div>
         </div>

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -76,74 +76,78 @@ export function NumberPad({
 
     return (
         <div className="number-pad">
-            {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => {
-                const full = (counts.get(n) ?? 0) >= 9
-                return (
-                    <button
-                        type="button"
-                        key={n}
-                        className={`num-btn${full ? " num-btn-complete" : ""}${flashDigits.has(n) ? " num-btn-flash" : ""}`}
-                        disabled={full}
-                        onClick={() => onNumber(n)}
-                    >
-                        {n}
-                    </button>
-                )
-            })}
-            <button
-                type="button"
-                className={`num-btn num-action${notesMode ? " notes-active" : ""}`}
-                onClick={onToggleNotesMode}
-            >
-                Notes
-            </button>
-            <button
-                type="button"
-                className="num-btn num-action"
-                disabled={undoDisabled}
-                onClick={onUndo}
-            >
-                Undo
-            </button>
-            <button
-                type="button"
-                className="num-btn num-action"
-                disabled={redoDisabled}
-                onClick={onRedo}
-            >
-                Redo
-            </button>
-            <button
-                type="button"
-                className="num-btn num-action num-danger"
-                onClick={onClear}
-            >
-                Erase
-            </button>
-            <button
-                type="button"
-                className="num-btn num-action num-accent"
-                disabled={won}
-                onClick={onHint}
-            >
-                Hint
-            </button>
-            <button
-                type="button"
-                className="num-btn num-action"
-                disabled={won}
-                onClick={onFillCell}
-            >
-                Notes✦
-            </button>
-            <button
-                type="button"
-                className="num-btn num-action"
-                disabled={won}
-                onClick={onFillLast}
-            >
-                Fill
-            </button>
+            <div className="num-row">
+                {[1, 2, 3, 4, 5, 6, 7, 8, 9].map((n) => {
+                    const full = (counts.get(n) ?? 0) >= 9
+                    return (
+                        <button
+                            type="button"
+                            key={n}
+                            className={`num-btn${full ? " num-btn-complete" : ""}${flashDigits.has(n) ? " num-btn-flash" : ""}`}
+                            disabled={full}
+                            onClick={() => onNumber(n)}
+                        >
+                            {n}
+                        </button>
+                    )
+                })}
+            </div>
+            <div className="num-row">
+                <button
+                    type="button"
+                    className={`num-btn num-action${notesMode ? " notes-active" : ""}`}
+                    onClick={onToggleNotesMode}
+                >
+                    Notes
+                </button>
+                <button
+                    type="button"
+                    className="num-btn num-action"
+                    disabled={undoDisabled}
+                    onClick={onUndo}
+                >
+                    Undo
+                </button>
+                <button
+                    type="button"
+                    className="num-btn num-action"
+                    disabled={redoDisabled}
+                    onClick={onRedo}
+                >
+                    Redo
+                </button>
+                <button
+                    type="button"
+                    className="num-btn num-action num-danger"
+                    onClick={onClear}
+                >
+                    Erase
+                </button>
+                <button
+                    type="button"
+                    className="num-btn num-action num-accent"
+                    disabled={won}
+                    onClick={onHint}
+                >
+                    Hint
+                </button>
+                <button
+                    type="button"
+                    className="num-btn num-action"
+                    disabled={won}
+                    onClick={onFillCell}
+                >
+                    Notes✦
+                </button>
+                <button
+                    type="button"
+                    className="num-btn num-action"
+                    disabled={won}
+                    onClick={onFillLast}
+                >
+                    Fill
+                </button>
+            </div>
         </div>
     )
 }

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -8,6 +8,8 @@ interface NumberPadProps {
     onUndo: () => void
     onRedo: () => void
     onHint: () => void
+    onFillCell: () => void
+    onFillLast: () => void
     undoDisabled: boolean
     redoDisabled: boolean
     notesMode: boolean
@@ -23,6 +25,8 @@ export function NumberPad({
     onUndo,
     onRedo,
     onHint,
+    onFillCell,
+    onFillLast,
     undoDisabled,
     redoDisabled,
     notesMode,
@@ -123,6 +127,22 @@ export function NumberPad({
                 onClick={onHint}
             >
                 Hint
+            </button>
+            <button
+                type="button"
+                className="num-btn fill-notes-btn"
+                disabled={won}
+                onClick={onFillCell}
+            >
+                Notes✦
+            </button>
+            <button
+                type="button"
+                className="num-btn fill-last-btn"
+                disabled={won}
+                onClick={onFillLast}
+            >
+                Fill
             </button>
         </div>
     )

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -92,14 +92,14 @@ export function NumberPad({
             })}
             <button
                 type="button"
-                className={`num-btn notes-btn${notesMode ? " notes-active" : ""}`}
+                className={`num-btn num-action${notesMode ? " notes-active" : ""}`}
                 onClick={onToggleNotesMode}
             >
                 Notes
             </button>
             <button
                 type="button"
-                className="num-btn undo-btn"
+                className="num-btn num-action"
                 disabled={undoDisabled}
                 onClick={onUndo}
             >
@@ -107,7 +107,7 @@ export function NumberPad({
             </button>
             <button
                 type="button"
-                className="num-btn redo-btn"
+                className="num-btn num-action"
                 disabled={redoDisabled}
                 onClick={onRedo}
             >
@@ -115,14 +115,14 @@ export function NumberPad({
             </button>
             <button
                 type="button"
-                className="num-btn erase-btn"
+                className="num-btn num-action erase-btn"
                 onClick={onClear}
             >
                 Erase
             </button>
             <button
                 type="button"
-                className="num-btn hint-btn"
+                className="num-btn num-action hint-btn"
                 disabled={won}
                 onClick={onHint}
             >
@@ -130,7 +130,7 @@ export function NumberPad({
             </button>
             <button
                 type="button"
-                className="num-btn fill-notes-btn"
+                className="num-btn num-action"
                 disabled={won}
                 onClick={onFillCell}
             >
@@ -138,7 +138,7 @@ export function NumberPad({
             </button>
             <button
                 type="button"
-                className="num-btn fill-last-btn"
+                className="num-btn num-action"
                 disabled={won}
                 onClick={onFillLast}
             >

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -115,14 +115,14 @@ export function NumberPad({
             </button>
             <button
                 type="button"
-                className="num-btn num-action erase-btn"
+                className="num-btn num-action num-danger"
                 onClick={onClear}
             >
                 Erase
             </button>
             <button
                 type="button"
-                className="num-btn num-action hint-btn"
+                className="num-btn num-action num-accent"
                 disabled={won}
                 onClick={onHint}
             >

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -37,17 +37,17 @@ beforeEach(() => {
 
 describe("SettingsPanel", () => {
     it("renders gear button", () => {
-        render(<SettingsPanel />)
+        render(<SettingsPanel difficulty="easy" onNewGame={vi.fn()} />)
         expect(screen.getByRole("button", { name: "Settings" })).toBeDefined()
     })
 
     it("panel is hidden by default", () => {
-        render(<SettingsPanel />)
+        render(<SettingsPanel difficulty="easy" onNewGame={vi.fn()} />)
         expect(screen.queryByText("System")).toBeNull()
     })
 
     it("clicking gear button opens the panel with all options", () => {
-        render(<SettingsPanel />)
+        render(<SettingsPanel difficulty="easy" onNewGame={vi.fn()} />)
         fireEvent.click(screen.getByRole("button", { name: "Settings" }))
         expect(screen.getByText("System")).toBeDefined()
         expect(screen.getByText("Light")).toBeDefined()
@@ -55,7 +55,7 @@ describe("SettingsPanel", () => {
     })
 
     it("clicking a theme option calls setTheme", () => {
-        render(<SettingsPanel />)
+        render(<SettingsPanel difficulty="easy" onNewGame={vi.fn()} />)
         fireEvent.click(screen.getByRole("button", { name: "Settings" }))
         fireEvent.click(screen.getByRole("button", { name: "Dark" }))
         expect(mockSetTheme).toHaveBeenCalledWith("dark")
@@ -63,7 +63,7 @@ describe("SettingsPanel", () => {
 
     it("active theme option has theme-option-active class", () => {
         mockThemeState.theme = "dark"
-        render(<SettingsPanel />)
+        render(<SettingsPanel difficulty="easy" onNewGame={vi.fn()} />)
         fireEvent.click(screen.getByRole("button", { name: "Settings" }))
         expect(
             screen.getByRole("button", { name: "Dark" }).className,
@@ -74,7 +74,7 @@ describe("SettingsPanel", () => {
     })
 
     it("clicking outside closes the panel", () => {
-        render(<SettingsPanel />)
+        render(<SettingsPanel difficulty="easy" onNewGame={vi.fn()} />)
         fireEvent.click(screen.getByRole("button", { name: "Settings" }))
         expect(screen.getByText("System")).toBeDefined()
         fireEvent.mouseDown(document.body)
@@ -82,7 +82,7 @@ describe("SettingsPanel", () => {
     })
 
     it("clicking gear again closes the panel", () => {
-        render(<SettingsPanel />)
+        render(<SettingsPanel difficulty="easy" onNewGame={vi.fn()} />)
         fireEvent.click(screen.getByRole("button", { name: "Settings" }))
         expect(screen.getByText("System")).toBeDefined()
         fireEvent.click(screen.getByRole("button", { name: "Settings" }))

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -1,10 +1,11 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-const { mockSetTheme, mockThemeState } = vi.hoisted(() => {
+const { mockSetTheme, mockThemeState, mockNewCustomGame } = vi.hoisted(() => {
     const mockThemeState = { theme: "system" }
     const mockSetTheme = vi.fn()
-    return { mockThemeState, mockSetTheme }
+    const mockNewCustomGame = vi.fn()
+    return { mockThemeState, mockSetTheme, mockNewCustomGame }
 })
 
 vi.mock("../store/themeStore", () => ({
@@ -15,6 +16,10 @@ vi.mock("../store/themeStore", () => ({
         { label: "Light", value: "light" },
         { label: "Dark", value: "dark" },
     ],
+}))
+
+vi.mock("../store/gameStore", () => ({
+    newCustomGame: mockNewCustomGame,
 }))
 
 vi.mock("valtio", () => ({

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,10 +1,12 @@
 import { Settings } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useSnapshot } from "valtio"
+import { newCustomGame } from "../store/gameStore"
 import { setTheme, THEME_OPTIONS, themeState } from "../store/themeStore"
 
 export function SettingsPanel() {
     const [open, setOpen] = useState(false)
+    const [customValue, setCustomValue] = useState(50)
     const panelRef = useRef<HTMLDivElement>(null)
     const snap = useSnapshot(themeState)
 
@@ -46,6 +48,31 @@ export function SettingsPanel() {
                                 {label}
                             </button>
                         ))}
+                    </div>
+                    <h3>Custom Difficulty</h3>
+                    <div className="custom-difficulty">
+                        <label htmlFor="custom-cells">Cells removed</label>
+                        <input
+                            id="custom-cells"
+                            type="number"
+                            min={20}
+                            max={64}
+                            value={customValue}
+                            onChange={(e) =>
+                                setCustomValue(Number(e.target.value))
+                            }
+                            className="custom-cells-input"
+                        />
+                        <button
+                            type="button"
+                            className="custom-play-btn"
+                            onClick={() => {
+                                newCustomGame(customValue)
+                                setOpen(false)
+                            }}
+                        >
+                            Play
+                        </button>
                     </div>
                 </div>
             )}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -4,8 +4,22 @@ import { useSnapshot } from "valtio"
 import { boardFromAscii } from "../export"
 import { loadBoard, newCustomGame } from "../store/gameStore"
 import { setTheme, THEME_OPTIONS, themeState } from "../store/themeStore"
+import type { Difficulty } from "../sudoku"
 
-export function SettingsPanel() {
+const DIFFICULTIES: Difficulty[] = [
+    "easy",
+    "medium",
+    "hard",
+    "master",
+    "expert",
+]
+
+interface SettingsPanelProps {
+    difficulty: Difficulty
+    onNewGame: (d: Difficulty) => void
+}
+
+export function SettingsPanel({ difficulty, onNewGame }: SettingsPanelProps) {
     const [open, setOpen] = useState(false)
     const [customValue, setCustomValue] = useState(50)
     const [importOpen, setImportOpen] = useState(false)
@@ -40,6 +54,22 @@ export function SettingsPanel() {
             </button>
             {open && (
                 <div className="settings-panel">
+                    <h3>Difficulty</h3>
+                    <div className="difficulty-group">
+                        {DIFFICULTIES.map((d) => (
+                            <button
+                                type="button"
+                                key={d}
+                                className={`diff-btn${difficulty === d ? " diff-active" : ""}`}
+                                onClick={() => {
+                                    onNewGame(d)
+                                    setOpen(false)
+                                }}
+                            >
+                                {d.charAt(0).toUpperCase() + d.slice(1)}
+                            </button>
+                        ))}
+                    </div>
                     <h3>Theme</h3>
                     <div className="theme-options">
                         {THEME_OPTIONS.map(({ label, value }) => (

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,12 +1,16 @@
 import { Settings } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useSnapshot } from "valtio"
-import { newCustomGame } from "../store/gameStore"
+import { boardFromAscii } from "../export"
+import { loadBoard, newCustomGame } from "../store/gameStore"
 import { setTheme, THEME_OPTIONS, themeState } from "../store/themeStore"
 
 export function SettingsPanel() {
     const [open, setOpen] = useState(false)
     const [customValue, setCustomValue] = useState(50)
+    const [importOpen, setImportOpen] = useState(false)
+    const [importText, setImportText] = useState("")
+    const [importError, setImportError] = useState(false)
     const panelRef = useRef<HTMLDivElement>(null)
     const snap = useSnapshot(themeState)
 
@@ -74,6 +78,61 @@ export function SettingsPanel() {
                             Play
                         </button>
                     </div>
+                    <h3>Import</h3>
+                    {!importOpen ? (
+                        <button
+                            type="button"
+                            className="import-open-btn"
+                            onClick={() => setImportOpen(true)}
+                        >
+                            Import ASCII board
+                        </button>
+                    ) : (
+                        <div className="import-section">
+                            <textarea
+                                className="import-textarea"
+                                placeholder="Paste ASCII board here..."
+                                value={importText}
+                                onChange={(e) => setImportText(e.target.value)}
+                                rows={11}
+                            />
+                            <div className="import-actions">
+                                <button
+                                    type="button"
+                                    className="import-load-btn"
+                                    onClick={() => {
+                                        const parsed =
+                                            boardFromAscii(importText)
+                                        if (!parsed || !loadBoard(parsed)) {
+                                            setImportError(true)
+                                            return
+                                        }
+                                        setImportOpen(false)
+                                        setImportText("")
+                                        setImportError(false)
+                                        setOpen(false)
+                                    }}
+                                >
+                                    Load
+                                </button>
+                                <button
+                                    type="button"
+                                    className="import-cancel-btn"
+                                    onClick={() => {
+                                        setImportOpen(false)
+                                        setImportError(false)
+                                    }}
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                            {importError && (
+                                <p className="import-error">
+                                    Could not parse board. Check the format.
+                                </p>
+                            )}
+                        </div>
+                    )}
                 </div>
             )}
         </div>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -43,7 +43,7 @@ export function SettingsPanel({ difficulty, onNewGame }: SettingsPanelProps) {
     }, [open])
 
     return (
-        <div ref={panelRef}>
+        <div ref={panelRef} className="settings-wrapper">
             <button
                 type="button"
                 className="settings-gear"

--- a/src/export.ts
+++ b/src/export.ts
@@ -1,3 +1,20 @@
+export function boardFromAscii(text: string): number[][] | null {
+    const dataLines = text
+        .split("\n")
+        .map((l) => l.trim())
+        .filter((l) => l.startsWith("|"))
+    if (dataLines.length !== 9) return null
+    const board: number[][] = []
+    for (const line of dataLines) {
+        const cells = line.replace(/\|/g, "").trim().split(/\s+/)
+        if (cells.length !== 9) return null
+        const row = cells.map((ch) => (ch === "." ? 0 : parseInt(ch, 10)))
+        if (row.some((v) => Number.isNaN(v) || v < 0 || v > 9)) return null
+        board.push(row)
+    }
+    return board.length === 9 ? board : null
+}
+
 const SEP = "+-------+-------+-------+"
 
 export function boardToAscii(board: number[][]): string {

--- a/src/hint.test.ts
+++ b/src/hint.test.ts
@@ -145,10 +145,10 @@ describe("getHint", () => {
         const hint = getHint(board, SOLUTION)
         expect(hint).not.toBeNull()
         expect(hint?.strategy).toBe("fallback")
-        // Fallback picks first empty cell [0][0], solution value = 5
+        // MRV on empty board: all cells have 9 candidates; first cell [0][0] wins
         expect(hint?.cell).toEqual({ row: 0, col: 0 })
         expect(hint?.value).toBe(SOLUTION[0][0])
-        expect(hint?.explanation).toContain("Try placing")
+        expect(hint?.explanation).toContain("candidates")
     })
 
     it("prefers a strategy over fallback when one applies", () => {

--- a/src/hint.ts
+++ b/src/hint.ts
@@ -121,28 +121,36 @@ export function findHiddenSingleInBox(board: Board): Hint | null {
 }
 
 export function getHint(board: Board, solution: Board): Hint | null {
-    // Check if board is already fully solved
+    const hasEmpty = board.some((row) => row.some((v) => v === 0))
+    if (!hasEmpty) return null
+
+    const hint =
+        findNakedSingle(board) ??
+        findHiddenSingleInRow(board) ??
+        findHiddenSingleInColumn(board) ??
+        findHiddenSingleInBox(board)
+    if (hint) return hint
+
+    // Fallback: most constrained cell (MRV heuristic — fewest candidates)
+    let bestCell: { row: number; col: number } | null = null
+    let bestCount = 10
     for (let r = 0; r < 9; r++) {
         for (let c = 0; c < 9; c++) {
-            if (board[r][c] === 0) {
-                // There are empty cells, proceed with strategies
-                const hint =
-                    findNakedSingle(board) ??
-                    findHiddenSingleInRow(board) ??
-                    findHiddenSingleInColumn(board) ??
-                    findHiddenSingleInBox(board)
-                if (hint) return hint
-
-                // Fallback: use solution
-                const value = solution[r][c]
-                return {
-                    cell: { row: r, col: c },
-                    value,
-                    strategy: "fallback",
-                    explanation: `Try placing ${value} here.`,
-                }
+            if (board[r][c] !== 0) continue
+            const count = getCandidates(board, r, c).length
+            if (count < bestCount) {
+                bestCount = count
+                bestCell = { row: r, col: c }
             }
         }
     }
-    return null
+    if (!bestCell) return null
+    const value = solution[bestCell.row][bestCell.col]
+    const noun = bestCount === 1 ? "candidate" : "candidates"
+    return {
+        cell: bestCell,
+        value,
+        strategy: "fallback",
+        explanation: `This cell has only ${bestCount} ${noun} — try placing ${value} here.`,
+    }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -600,6 +600,34 @@ h1 {
     border-color: var(--color-primary);
 }
 
+.custom-difficulty {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 4px;
+}
+
+.custom-cells-input {
+    width: 56px;
+    padding: 4px 8px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-btn);
+    background: var(--color-surface);
+    color: var(--color-text);
+    font-size: 0.9rem;
+    text-align: center;
+}
+
+.custom-play-btn {
+    padding: 4px 12px;
+    border: 1px solid var(--color-primary);
+    border-radius: var(--radius-btn);
+    background: var(--color-primary);
+    color: var(--color-text-on-primary);
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
 @media (max-width: 380px) {
     .win-message {
         padding: 24px;

--- a/src/index.css
+++ b/src/index.css
@@ -365,40 +365,32 @@ h1 {
     animation: digit-complete-flash 1.4s ease-out;
 }
 
-.notes-btn {
-    width: auto;
-    padding: 0 16px;
+.num-action {
     font-size: 0.85rem;
     color: var(--color-text-muted);
 }
 
-.notes-btn.notes-active {
+.notes-active {
     background: var(--color-primary);
     color: var(--color-text-on-primary);
     border-color: var(--color-primary);
 }
 
-.undo-btn,
-.redo-btn {
-    width: auto;
-    padding: 0 16px;
-    font-size: 0.85rem;
-    color: var(--color-text-muted);
-}
-
 .erase-btn {
-    width: auto;
-    padding: 0 16px;
-    font-size: 0.85rem;
     color: var(--color-text-error);
 }
 
 .hint-btn {
+    color: var(--color-hint);
+    border-color: var(--color-hint-border);
+}
+
+.fill-notes-btn,
+.fill-last-btn {
     width: auto;
     padding: 0 16px;
     font-size: 0.85rem;
-    color: var(--color-hint);
-    border-color: var(--color-hint-border);
+    color: var(--color-text-muted);
 }
 
 /* Win overlay */

--- a/src/index.css
+++ b/src/index.css
@@ -512,6 +512,12 @@ h1 {
     box-shadow: 0 1px 0 var(--color-border-shadow);
 }
 
+@media (pointer: coarse) {
+    .status-bar-shortcut {
+        display: none;
+    }
+}
+
 @keyframes status-fade-in {
     from {
         opacity: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -628,6 +628,69 @@ h1 {
     cursor: pointer;
 }
 
+.import-open-btn {
+    width: 100%;
+    padding: 6px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-btn);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    font-size: 0.85rem;
+    cursor: pointer;
+    text-align: center;
+}
+
+.import-section {
+    margin-top: 4px;
+}
+
+.import-textarea {
+    width: 100%;
+    font-family: monospace;
+    font-size: 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-btn);
+    background: var(--color-surface);
+    color: var(--color-text);
+    padding: 8px;
+    resize: none;
+    box-sizing: border-box;
+}
+
+.import-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.import-load-btn {
+    flex: 1;
+    padding: 6px;
+    background: var(--color-primary);
+    color: var(--color-text-on-primary);
+    border: none;
+    border-radius: var(--radius-btn);
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+
+.import-cancel-btn {
+    flex: 1;
+    padding: 6px;
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-btn);
+    cursor: pointer;
+    font-size: 0.85rem;
+}
+
+.import-error {
+    color: var(--color-error, #f85149);
+    font-size: 0.8rem;
+    margin-top: 6px;
+}
+
 @media (max-width: 380px) {
     .win-message {
         padding: 24px;

--- a/src/index.css
+++ b/src/index.css
@@ -98,19 +98,12 @@ button:focus-visible {
     --color-hint-border: #d4a017;
 }
 
-html {
-    height: 100%;
-    overscroll-behavior: none;
-}
-
 body {
     font-family: system-ui, -apple-system, sans-serif;
     background: var(--color-bg);
     display: flex;
     justify-content: center;
-    height: 100%;
-    overflow: hidden;
-    overscroll-behavior: none;
+    min-height: 100vh;
 }
 
 .app {
@@ -123,8 +116,26 @@ body {
         max(16px, env(safe-area-inset-left));
     max-width: 540px;
     width: 100%;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
+}
+
+/* Mobile: lock page scroll to prevent bounce/drag in PWA and Safari */
+@media (pointer: coarse) {
+    html {
+        height: 100%;
+        overscroll-behavior: none;
+    }
+
+    body {
+        height: 100%;
+        min-height: unset;
+        overflow: hidden;
+        overscroll-behavior: none;
+    }
+
+    .app {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
 }
 
 h1 {

--- a/src/index.css
+++ b/src/index.css
@@ -299,8 +299,7 @@ h1 {
 /* Number pad */
 .number-pad {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
+    flex-direction: column;
     gap: 6px;
     margin-top: 20px;
     max-width: calc(
@@ -312,6 +311,11 @@ h1 {
         4
     );
     width: 100%;
+}
+
+.num-row {
+    display: flex;
+    gap: 6px;
 }
 
 .num-btn {

--- a/src/index.css
+++ b/src/index.css
@@ -141,7 +141,7 @@ body {
 .app-header {
     display: flex;
     align-items: baseline;
-    justify-content: space-between;
+    gap: 12px;
     width: 100%;
     max-width: calc(
         var(--cell-size) *

--- a/src/index.css
+++ b/src/index.css
@@ -98,12 +98,19 @@ button:focus-visible {
     --color-hint-border: #d4a017;
 }
 
+html {
+    height: 100%;
+    overscroll-behavior: none;
+}
+
 body {
     font-family: system-ui, -apple-system, sans-serif;
     background: var(--color-bg);
     display: flex;
     justify-content: center;
-    min-height: 100vh;
+    height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;
 }
 
 .app {
@@ -116,6 +123,8 @@ body {
         max(16px, env(safe-area-inset-left));
     max-width: 540px;
     width: 100%;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 h1 {
@@ -521,9 +530,9 @@ h1 {
     right: max(16px, env(safe-area-inset-right));
     width: 36px;
     height: 36px;
-    border: 1px solid var(--color-border);
+    border: 1px solid transparent;
     border-radius: var(--radius-btn);
-    background: var(--color-surface);
+    background: transparent;
     color: var(--color-text-muted);
     cursor: pointer;
     display: flex;
@@ -533,8 +542,10 @@ h1 {
     transition: all 0.15s;
 }
 
-.settings-gear:hover {
-    border-color: var(--color-primary);
+.settings-gear:hover,
+.settings-gear:active {
+    border-color: var(--color-border);
+    background: var(--color-surface);
     color: var(--color-primary);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -537,9 +537,12 @@ h1 {
 }
 
 /* Settings panel */
+.spacer {
+    flex: 1;
+}
+
 .settings-wrapper {
     position: relative;
-    margin-left: auto;
 }
 
 .settings-gear {

--- a/src/index.css
+++ b/src/index.css
@@ -138,16 +138,9 @@ body {
     }
 }
 
-h1 {
-    font-size: 1.8rem;
-    color: var(--color-text);
-    margin-bottom: 16px;
-}
-
-/* Toolbar */
-.toolbar {
+.app-header {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     justify-content: space-between;
     width: 100%;
     max-width: calc(
@@ -161,8 +154,14 @@ h1 {
     margin-bottom: 16px;
 }
 
+h1 {
+    font-size: 1.8rem;
+    color: var(--color-text);
+}
+
 .difficulty-group {
     display: flex;
+    flex-wrap: wrap;
     gap: 6px;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -520,7 +520,7 @@ h1 {
 }
 
 @media (pointer: coarse) {
-    .status-bar-shortcut {
+    .status-bar {
         display: none;
     }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -140,7 +140,7 @@ body {
 
 .app-header {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 12px;
     width: 100%;
     max-width: calc(
@@ -537,10 +537,12 @@ h1 {
 }
 
 /* Settings panel */
+.settings-wrapper {
+    position: relative;
+    margin-left: auto;
+}
+
 .settings-gear {
-    position: fixed;
-    top: max(16px, env(safe-area-inset-top));
-    right: max(16px, env(safe-area-inset-right));
     width: 36px;
     height: 36px;
     border: 1px solid transparent;
@@ -551,7 +553,6 @@ h1 {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 100;
     transition: all 0.15s;
 }
 
@@ -563,9 +564,9 @@ h1 {
 }
 
 .settings-panel {
-    position: fixed;
-    top: max(60px, calc(env(safe-area-inset-top) + 44px));
-    right: max(16px, env(safe-area-inset-right));
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
     background: var(--color-surface);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-panel);

--- a/src/index.css
+++ b/src/index.css
@@ -376,11 +376,11 @@ h1 {
     border-color: var(--color-primary);
 }
 
-.erase-btn {
+.num-danger {
     color: var(--color-text-error);
 }
 
-.hint-btn {
+.num-accent {
     color: var(--color-hint);
     border-color: var(--color-hint-border);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -566,16 +566,21 @@ h1 {
     padding: 16px;
     z-index: 99;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-    min-width: 180px;
+    min-width: 260px;
 }
 
 .settings-panel h3 {
     font-size: 0.8rem;
     font-weight: 600;
-    color: var(--color-text-faint);
+    color: var(--color-text-muted);
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    margin-bottom: 10px;
+    margin-top: 20px;
+    margin-bottom: 8px;
+}
+
+.settings-panel h3:first-child {
+    margin-top: 0;
 }
 
 .theme-options {
@@ -609,13 +614,20 @@ h1 {
 
 .custom-difficulty {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 8px;
-    margin-top: 4px;
+}
+
+.custom-difficulty label {
+    flex: 0 0 100%;
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
 }
 
 .custom-cells-input {
-    width: 56px;
+    flex: 1;
+    min-width: 60px;
     padding: 4px 8px;
     border: 1px solid var(--color-border);
     border-radius: var(--radius-btn);
@@ -626,7 +638,8 @@ h1 {
 }
 
 .custom-play-btn {
-    padding: 4px 12px;
+    flex: 0 0 auto;
+    padding: 4px 16px;
     border: 1px solid var(--color-primary);
     border-radius: var(--radius-btn);
     background: var(--color-primary);

--- a/src/index.css
+++ b/src/index.css
@@ -305,7 +305,8 @@ h1 {
 
 .num-btn {
     position: relative;
-    width: calc(var(--cell-size) * 0.85);
+    flex: 1 1 auto;
+    min-width: calc(var(--cell-size) * 0.7);
     height: calc(var(--cell-size) * 0.85);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-btn);

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -3,8 +3,10 @@ import { proxyWithHistory } from "valtio-history"
 import {
     type Board,
     type Difficulty,
+    generateCustomPuzzle,
     generatePuzzle,
     isValidPlacement,
+    solve,
 } from "../sudoku"
 
 export interface CellPos {
@@ -24,6 +26,7 @@ interface GameUI {
     difficulty: Difficulty
     elapsed: number
     notesMode: boolean
+    customCells: number | null
 }
 
 function emptyNotes(): number[][][] {
@@ -51,6 +54,7 @@ function createInitialUI(
         difficulty,
         elapsed: 0,
         notesMode: false,
+        customCells: null,
     }
 }
 
@@ -228,6 +232,46 @@ export function newGame(difficulty: Difficulty) {
     gameUI.difficulty = ui.difficulty
     gameUI.elapsed = ui.elapsed
     gameUI.notesMode = ui.notesMode
+    gameUI.customCells = null
+}
+
+export function newCustomGame(cellsToRemove: number) {
+    const { puzzle, solution } = generateCustomPuzzle(cellsToRemove)
+
+    const data = createInitialData(puzzle)
+    gameData.value.board = data.board
+    gameData.value.notes = data.notes
+    gameData.history.nodes.splice(0)
+    gameData.history.index = -1
+    gameData.saveHistory()
+
+    const ui = createInitialUI(solution, puzzle, "easy")
+    gameUI.solution = ui.solution
+    gameUI.initial = ui.initial
+    gameUI.selected = ui.selected
+    gameUI.elapsed = 0
+    gameUI.notesMode = false
+    gameUI.customCells = Math.max(20, Math.min(64, cellsToRemove))
+}
+
+export function loadBoard(puzzle: number[][]): boolean {
+    const solutionBoard = puzzle.map((row) => [...row])
+    if (!solve(solutionBoard)) return false
+
+    const data = createInitialData(puzzle.map((row) => [...row]))
+    gameData.value.board = data.board
+    gameData.value.notes = data.notes
+    gameData.history.nodes.splice(0)
+    gameData.history.index = -1
+    gameData.saveHistory()
+
+    gameUI.solution = solutionBoard
+    gameUI.initial = puzzle.map((row) => row.map((v) => v !== 0))
+    gameUI.selected = null
+    gameUI.elapsed = 0
+    gameUI.notesMode = false
+    gameUI.customCells = null
+    return true
 }
 
 export function findLastOneCell(

--- a/src/sudoku.ts
+++ b/src/sudoku.ts
@@ -112,6 +112,36 @@ export function generateSolvedBoard(): Board {
     return board
 }
 
+export function generateCustomPuzzle(cellsToRemove: number): {
+    puzzle: Board
+    solution: Board
+} {
+    const clamped = Math.max(20, Math.min(64, cellsToRemove))
+    const solution = generateSolvedBoard()
+    const puzzle = solution.map((row) => [...row])
+
+    const positions = shuffle(
+        Array.from(
+            { length: 81 },
+            (_, i) => [Math.floor(i / 9), i % 9] as [number, number],
+        ),
+    )
+
+    let removed = 0
+    for (const [r, c] of positions) {
+        if (removed >= clamped) break
+        const saved = puzzle[r][c]
+        puzzle[r][c] = 0
+        if (!hasUniqueSolution(puzzle)) {
+            puzzle[r][c] = saved
+        } else {
+            removed++
+        }
+    }
+
+    return { puzzle, solution }
+}
+
 export function generatePuzzle(difficulty: Difficulty): {
     puzzle: Board
     solution: Board

--- a/src/sudoku.ts
+++ b/src/sudoku.ts
@@ -1,5 +1,5 @@
 export type Board = number[][]
-export type Difficulty = "easy" | "medium" | "hard" | "expert"
+export type Difficulty = "easy" | "medium" | "hard" | "master" | "expert"
 
 export function isValidPlacement(
     board: Board,
@@ -123,6 +123,7 @@ export function generatePuzzle(difficulty: Difficulty): {
         easy: 38,
         medium: 46,
         hard: 53,
+        master: 55,
         expert: 58,
     }
 

--- a/src/useGame.ts
+++ b/src/useGame.ts
@@ -63,6 +63,7 @@ export function useGame() {
         elapsed: uiSnap.elapsed,
         notes: dataSnap.value.notes as number[][][],
         notesMode: uiSnap.notesMode,
+        customCells: uiSnap.customCells,
         canUndo: gameData.history.index > 0,
         canRedo: gameData.history.index < gameData.history.nodes.length - 1,
         selectCell,


### PR DESCRIPTION
## Summary

- **Mobile scroll/PWA drag** — `html`/`body` use `height:100%` + `overflow:hidden` + `overscroll-behavior:none`; `.app` scrolls internally
- **Ghost gear button** — transparent border/background at rest, visible only on hover/tap
- **Master difficulty** — new level between hard (53) and expert (58) removing 55 cells
- **Mobile fill buttons** — "Notes✦" and "Fill" buttons added to number pad, wired to existing `fillCandidateNotes` / `fillLastDigit`
- **Custom complexity** — settings panel number input + Play button calls new `newCustomGame(n)`
- **MRV hint fallback** — replaces top-left scan with minimum-remaining-values heuristic; explanation mentions candidate count
- **ASCII board import** — settings panel Import section: paste exported ASCII, validate, load via new `boardFromAscii` + `loadBoard`

Closes #32